### PR TITLE
Disable relative line numbers in nvim

### DIFF
--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -174,7 +174,7 @@ set nocursorline
 set encoding=utf-8
 
 " Additional visual improvements
-set relativenumber      " Show relative line numbers
+" set relativenumber      " Show relative line numbers (disabled)
 set scrolloff=8         " Keep 8 lines above/below cursor
 set sidescrolloff=8     " Keep 8 columns left/right of cursor
 set signcolumn=yes      " Always show sign column

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -174,7 +174,7 @@ set nocursorline
 set encoding=utf-8
 
 " Additional visual improvements
-" set relativenumber      " Show relative line numbers (disabled)
+set norelativenumber    " Disable relative line numbers
 set scrolloff=8         " Keep 8 lines above/below cursor
 set sidescrolloff=8     " Keep 8 columns left/right of cursor
 set signcolumn=yes      " Always show sign column


### PR DESCRIPTION
## Summary
- Disabled relative line numbers in nvim configuration by commenting out `set relativenumber`
- Line numbers now show absolute numbers instead of relative distance from cursor position

## Changes
- Comment out line 177 in `nvim/init.vim` that enables relative line numbers

This change improves the editing experience by showing traditional absolute line numbers.